### PR TITLE
Changing statusCode from required to optional

### DIFF
--- a/src/MBW.Client.SslLabsLib/Objects/HttpTransaction.cs
+++ b/src/MBW.Client.SslLabsLib/Objects/HttpTransaction.cs
@@ -12,7 +12,7 @@ public class HttpTransaction
     /// <summary>
     /// Response status code
     /// </summary>
-    public int StatusCode { get; set; }
+    public int? StatusCode { get; set; }
 
     /// <summary>
     /// The entire request line as a single field


### PR DESCRIPTION
I  noticed that sometimes the SSL Labs server responds with a JSON result including a 'null' value for the statusCode field. This change is to reflect this possible response.

Note that this is a breaking change for any existing .NET applications, they should now use .StatusCode.Value instead of .StatusCode if they need the (int) value instead of the (int?) value.